### PR TITLE
Add kong cli  parser and refactor capture cmd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 smart-camera
 data
+Makefile.options

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+-include Makefile.options
+######################################################################################
+BIN_DIR=$(PWD)/bin
+BIN_NAME=smart-camera
+######################################################################################
+$(BIN_DIR):
+	mkdir $(BIN_DIR)
+build: | $(BIN_DIR)
+	(cd cmd/cli && CGO_ENABLED=0 GOOS=linux GOARCH=arm GOARM=5 go build -o $(BIN_DIR)/$(BIN_NAME))
+######################################################################################
+clean:
+	rm -r -f $(BIN_DIR)
+
+######################################################################################
+rpi/upload: $(BIN_DIR)/$(BIN_NAME)
+	rsync -P $(BIN_DIR)/$(BIN_NAME) $(RPI_USER_URL):$(RPI_DIR)
+
+rpi/ssh:
+	ssh $(RPI_USER_URL)
+
+rpi/dwn-images: 
+	rsync -P -r $(RPI_USER_URL):$(RPI_DIR)/data ./data
+######################################################################################

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"time"
+
+	"github.com/alecthomas/kong"
+	"github.com/arribada/smart-camera/pkg/capturer"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/oklog/run"
+	"github.com/pkg/errors"
+)
+
+var cli struct {
+	Capture capturer.Config `cmd:"" help:"Captures images to directory"`
+}
+
+func main() {
+	kongCtx := kong.Parse(&cli, kong.UsageOnError())
+
+	logger := NewLogger()
+	globalCtx, globalShutdown := context.WithCancel(context.Background())
+	defer globalShutdown()
+
+	switch kongCtx.Command() {
+	case "capture":
+		runCapture(globalCtx, logger, cli.Capture)
+	default:
+		ExitOnError(logger, errors.Errorf("unknown cmd: %s", kongCtx.Command()), "initialization")
+	}
+	
+	level.Info(logger).Log("msg", "main shutdown complete")
+}
+
+const DefaultTimeFormat = "02 Jan 15:04:05.00"
+
+// NewLogger create a new logger.
+func NewLogger() log.Logger {
+	logger := log.NewLogfmtLogger(log.NewSyncWriter(os.Stderr))
+	return log.With(logger, "ts", log.TimestampFormat(func() time.Time { return time.Now().UTC() }, DefaultTimeFormat), "caller", log.Caller(5))
+}
+
+func ExitOnError(logger log.Logger, err error, msg string) {
+	if err != nil {
+		level.Error(logger).Log("msg", msg, "err", err)
+		os.Exit(1)
+	}
+}
+
+func runCapture(ctx context.Context, logger log.Logger, cfg capturer.Config) {
+	var g run.Group
+	// Run groups.
+	{
+		// Handle interupts.
+		g.Add(run.SignalHandler(context.Background(), syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM))
+
+		capt, err := capturer.New(ctx, logger, cfg)
+		ExitOnError(logger, err, "creating component:"+capturer.ComponentName)
+
+		g.Add(func() error {
+			capt.Start()
+			level.Info(logger).Log("msg", "shutdown complete", "component", capturer.ComponentName)
+			return nil
+		}, func(error) {
+			capt.Stop()
+		})
+	}
+
+	if err := g.Run(); err != nil {
+		level.Error(logger).Log("msg", "main exited with error", "err", err)
+		return
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 )
 
 require (
+	github.com/alecthomas/kong v0.4.0
 	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/google/uuid v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,6 @@
+github.com/alecthomas/kong v0.4.0 h1:uj5Xe5RaoSRu2sUIy6XZk5QO9NaLU7/+2HXq7GRas/4=
+github.com/alecthomas/kong v0.4.0/go.mod h1:uzxf/HUh0tj43x1AyJROl3JT7SgsZ5m+icOv1csRhc0=
+github.com/alecthomas/repr v0.0.0-20210801044451-80ca428c5142/go.mod h1:2kn6fqh/zIyPLmm3ugklbEi5hg5wS435eygvNfaDQL8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -61,6 +64,7 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201216223049-8b5274cf687f h1:aZp0e2vLN4MToVqnjNEYEtrEA8RH8U8FN1CU7JgqsPU=
@@ -88,3 +92,5 @@ gopkg.in/ini.v1 v1.57.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Initial pull request for moving to kong for review. 

I tried to prepare new main.go. What was done:
 - added kong command `capture`
 - dropped reading from .env file as I don't know what to do with the file for the capture cmd
 - dropped upload to s3 in main - we could add cmd in future for it
 - run.Group - now it is in runCapture func. Will move it back to main if new command will require to use it also.
 - made some changes in capturer.go - allow customizing file ext.

Sample cmd usage:
```bash
./smart-camera capture --ext .jpg --data-folder data --interval 1m
```

